### PR TITLE
[GPU][SYCL_LZ] Fix qwen 0.5b fp16 model issue: result is wrong.

### DIFF
--- a/src/plugins/intel_gpu/src/graph/impls/registry/fully_connected_impls.cpp
+++ b/src/plugins/intel_gpu/src/graph/impls/registry/fully_connected_impls.cpp
@@ -22,8 +22,8 @@ using namespace cldnn;
 
 const std::vector<std::shared_ptr<cldnn::ImplementationManager>>& Registry<fully_connected>::get_implementations() {
     static const std::vector<std::shared_ptr<ImplementationManager>> impls = {
-        OV_GPU_CREATE_INSTANCE_SYCL_LZ(sycl_lz::FullyConnectedImplementationManager, shape_types::static_shape)
-        OV_GPU_CREATE_INSTANCE_SYCL_LZ(sycl_lz::FullyConnectedImplementationManager, shape_types::dynamic_shape)
+        // OV_GPU_CREATE_INSTANCE_SYCL_LZ(sycl_lz::FullyConnectedImplementationManager, shape_types::static_shape)
+        // OV_GPU_CREATE_INSTANCE_SYCL_LZ(sycl_lz::FullyConnectedImplementationManager, shape_types::dynamic_shape)
         OV_GPU_CREATE_INSTANCE_ONEDNN(onednn::FullyConnectedImplementationManager, shape_types::static_shape)
         OV_GPU_GET_INSTANCE_OCL(fully_connected, shape_types::static_shape)
         OV_GPU_GET_INSTANCE_OCL(fully_connected, shape_types::dynamic_shape,

--- a/src/plugins/intel_gpu/src/runtime/sycl_lz/sycl_lz_engine.cpp
+++ b/src/plugins/intel_gpu/src/runtime/sycl_lz/sycl_lz_engine.cpp
@@ -17,11 +17,12 @@ namespace sycl_lz {
 sycl_lz_engine::sycl_lz_engine(const device::ptr dev, runtime_types runtime_type)
 : engine(dev) {
     GPU_DEBUG_INFO << "create sycl_lz_engine" << std::endl;
-    // : ocl_engine(dev, runtime_type) {
 
     auto casted_dev = dynamic_cast<sycl_lz::sycl_lz_device*>(_device.get());
     auto device = casted_dev->get_device();
     sycl_context = cldnn::make_unique<::sycl::context>(device);
+
+    _service_stream.reset(new sycl_lz_stream(*this, ExecutionConfig()));
 }
 
 stream::ptr sycl_lz_engine::create_stream(const ExecutionConfig& config) const {

--- a/src/plugins/intel_gpu/src/runtime/sycl_lz/sycl_lz_ext.hpp
+++ b/src/plugins/intel_gpu/src/runtime/sycl_lz/sycl_lz_ext.hpp
@@ -73,10 +73,10 @@ public:
             *ret_event = ev;
         } else {
             ev.wait();
-            sycl::half* dst_ptr_f16 = static_cast<sycl::half*>(dst_ptr);
-            GPU_DEBUG_LOG << "  == host dst_ptr[0:3]=" << static_cast<float>(dst_ptr_f16[0]) << ", "
-                          << static_cast<float>(dst_ptr_f16[1]) << ", " << static_cast<float>(dst_ptr_f16[2]) << ", "
-                          << static_cast<float>(dst_ptr_f16[3]) << std::endl;
+            // sycl::half* dst_ptr_f16 = static_cast<sycl::half*>(dst_ptr);
+            // GPU_DEBUG_LOG << "  == host dst_ptr[0:3]=" << static_cast<float>(dst_ptr_f16[0]) << ", "
+            //               << static_cast<float>(dst_ptr_f16[1]) << ", " << static_cast<float>(dst_ptr_f16[2]) << ", "
+            //               << static_cast<float>(dst_ptr_f16[3]) << std::endl;
         }
         return 0;
     }
@@ -88,8 +88,17 @@ public:
                             size_t bytes_count,
                             const std::vector<sycl::event>* wait_list = nullptr,
                             sycl::event* ret_event = nullptr) const {
-        GPU_DEBUG_LOG << "Not implemented." << std::endl;
+        GPU_DEBUG_LOG << "Temp Solution, fill memory. " << std::endl;
+        auto new_queue = cpp_queue;
+        auto ev = new_queue.submit([&](sycl::handler& cgh) {
+            cgh.memcpy(dst_ptr, pattern, bytes_count);
+        });
 
+        if (ret_event) {
+            *ret_event = ev;
+        } else {
+            ev.wait();
+        }
         return 0;
     }
 


### PR DESCRIPTION
1: Disable my SYCL fc;
2: Implement SYCL runtime copy_from and copy_to; 

I can get correct result for "models_328feb63_ww50.4_optimum/qwen2-0.5b/pytorch/dldt/FP16"
Diff still exist via comparing the dump raw data.
For example: (compare last layer dump data, program1_network1_0_rms___module.model.norm_aten__mul_Multiply_1_dst0.txt)

```
@- Line-5373 3.392578
#+ Line-5373 3.333984

@- Line-5374 0.372803
#+ Line-5374 0.360840

@- Line-5375 4.390625
#+ Line-5375 4.402344

@- Line-5376 0.051727
#+ Line-5376 0.039490

@- Line-5377 -1.617188
#+ Line-5377 -1.562500

Total diff: 4368 / 5378
```
