### PR TITLE
[GPU][SYCL LEVELZERO] Fix oneDNN performance issue.

### DIFF
--- a/src/plugins/intel_gpu/src/runtime/sycl_lz/sycl_lz_device.cpp
+++ b/src/plugins/intel_gpu/src/runtime/sycl_lz/sycl_lz_device.cpp
@@ -310,9 +310,13 @@ device_info init_device_info(const sycl::device& device) {
     //     (info.gfx_ver.major == 12 && info.gfx_ver.minor >= 70)) {
     //     info.has_separate_cache = true;
     // }
-    //     GPU_DEBUG_INFO << "GPU version: " << static_cast<int>(info.gfx_ver.major) << "."
-    //                    << static_cast<int>(info.gfx_ver.minor) << "." << static_cast<int>(info.gfx_ver.revision)
-    //                    << (info.has_separate_cache ? " with separate cache" : "") << std::endl;
+    GPU_DEBUG_LOG << "Temp implemented. oneDNN need this `info.has_separate_cache` to check if "
+                     "transfer_memory_to_device. So set info.has_separate_cache to true."
+                  << std::endl;
+    info.has_separate_cache = true;
+    GPU_DEBUG_INFO << "GPU version: " << static_cast<int>(info.gfx_ver.major) << "."
+                   << static_cast<int>(info.gfx_ver.minor) << "." << static_cast<int>(info.gfx_ver.revision)
+                   << (info.has_separate_cache ? " with separate cache" : "") << std::endl;
     //     GPU_DEBUG_GET_INSTANCE(debug_config);
     //     GPU_DEBUG_IF(debug_config->disable_onednn)
     //     info.supports_immad = false;

--- a/src/plugins/intel_gpu/src/runtime/sycl_lz/sycl_lz_stream.cpp
+++ b/src/plugins/intel_gpu/src/runtime/sycl_lz/sycl_lz_stream.cpp
@@ -237,14 +237,14 @@ void sycl_lz_stream::set_arguments(kernel& kernel,
 
 inline sycl::range<3> toSyclRange(const std::vector<size_t>& v) {
     switch (v.size()) {
-        case 1:
-            return sycl::range(v[0], 1, 1);
-        case 2:
-            return sycl::range(v[1], v[0], 1);
-        case 3:
-            return sycl::range(v[2], v[1], v[0]);
-        default:
-            return sycl::range{1, 1, 1};
+    case 1:
+        return sycl::range(1, 1, v[0]);
+    case 2:
+        return sycl::range(1, v[1], v[0]);
+    case 3:
+        return sycl::range(v[2], v[1], v[0]);
+    default:
+        return sycl::range{1, 1, 1};
     }
 }
 


### PR DESCRIPTION
1: Fix gemm onednn kernel performance issue. Change `info.has_separate_cach`e default value to true.
Verify pass based on test [case](https://github.com/xipingyan/ov_self_build_model_example/blob/35a58e9e3ba0995e79e8dd9b8b69f1691cde92b6/python/model_gemm.py). 
2: Upgade OpenCL group to SYCL group algorithm;
