### PR TITLE
[GPU][SYCL L0] Remove queue.wait when OpenCL call clFlush.

### DIFF
--- a/src/plugins/intel_gpu/src/runtime/sycl_lz/sycl_lz_stream.cpp
+++ b/src/plugins/intel_gpu/src/runtime/sycl_lz/sycl_lz_stream.cpp
@@ -47,8 +47,7 @@ sycl_lz_stream::sycl_lz_stream(const sycl_lz_engine& engine, const ExecutionConf
 
 void sycl_lz_stream::flush() const {
     // Issues all previously queued OpenCL commands in a command-queue to the device associated with the command-queue.
-    GPU_DEBUG_LOG << "Not implemented. sycl_lz_stream::flush(), maybe sycl doesn't need it." << std::endl;
-    sycl_queue->wait();
+    GPU_DEBUG_LOG << "Not implemented. There is no mirror function of clFlush. SYCL doesn't need it." << std::endl;
 }
 
 void sycl_lz_stream::finish() const {
@@ -58,7 +57,8 @@ void sycl_lz_stream::finish() const {
 
 void sycl_lz_stream::wait() {
     GPU_DEBUG_LOG << "Temp implemented. sycl_queue->wait();" << std::endl;
-    sycl_queue->wait();
+    // sycl_queue->wait();
+    sycl_queue->ext_oneapi_submit_barrier().wait();
 }
 
 cl_int set_kernel_arg_sycl_kernel(const std::string& kernel_id,

--- a/src/plugins/intel_gpu/src/runtime/sycl_lz/sycl_lz_stream.cpp
+++ b/src/plugins/intel_gpu/src/runtime/sycl_lz/sycl_lz_stream.cpp
@@ -99,7 +99,6 @@ std::vector<sycl_args> set_arguments_impl_sycl_kernel(const arguments_desc& args
                                                       const kernel_arguments_data& data,
                                                       const std::string& kernel_id) {
     using args_t = argument_desc::Types;
-    using scalar_t = scalar_desc::Types;
 
     static std::mutex m;
     std::lock_guard<std::mutex> guard(m);
@@ -268,7 +267,6 @@ event::ptr sycl_lz_stream::enqueue_kernel(kernel& kernel,
                   << ndr.get_local_range()[2] << "]" << std::endl;
 
     std::vector<sycl::event> dep_events;
-    std::vector<sycl::event>* dep_events_ptr = nullptr;
     if (m_sync_method == SyncMethods::events) {
         for (auto& dep : deps) {
             if (auto ocl_base_ev = std::dynamic_pointer_cast<sycl_lz_base_event>(dep)) {
@@ -276,7 +274,6 @@ event::ptr sycl_lz_stream::enqueue_kernel(kernel& kernel,
                 dep_events.push_back(ocl_base_ev->get());
             }
         }
-        dep_events_ptr = &dep_events;
     } else if (m_sync_method == SyncMethods::barriers) {
         // sync_events(deps, is_output);
         GPU_DEBUG_LOG << "Not implemented. m_sync_method == SyncMethods::barriers." << std::endl;


### PR DESCRIPTION
For SYCL, there is no corresponding function, comparing with OpenCL clFlush.
