### PR TITLE
[GPU] Update primitive_inst.cpp to fix build fail issue.

### DIFF
--- a/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
+++ b/src/plugins/intel_gpu/src/graph/primitive_inst.cpp
@@ -2702,7 +2702,7 @@ bool primitive_inst::is_valid_fusion() const {
         }
     }
 
-    const auto& out_pshape = (_unfused_subgraph != nullptr && !get_flag(ExecutionFlags::SHAPE_CHANGED)) ?
+    const auto out_pshape = (_unfused_subgraph != nullptr && !get_flag(ExecutionFlags::SHAPE_CHANGED)) ?
                             _unfused_subgraph->get_primitive(get_node().id())->get_output_layout().get_partial_shape() :
                             _impl_params->get_output_layout().get_partial_shape();
     for (auto& fd : fused_eltwise_prims) {


### PR DESCRIPTION
openvino/src/plugins/intel_gpu/src/graph/primitive_inst.cpp:2702:17: error: possibly dangling reference to a temporary [-Werror=dangling-reference]
 2702 |     const auto& out_pshape = (_unfused_subgraph != nullptr && !get_flag(ExecutionFlags::SHAPE_CHANGED)) ?
      |                 ^~~~~~~~~~

